### PR TITLE
ItemTableとUserInfoコンポーネントの一新

### DIFF
--- a/app/(home)/page.tsx
+++ b/app/(home)/page.tsx
@@ -52,7 +52,15 @@ export default function Home() {
             <ApiKeyModal onRegister={handleRegister} />
           </div>
         </div>
-        <ItemtableContainer TableContent={loading ? <TableSkeleton /> : <ItemTableContent itemDatas={itemDatas} />}/>
+        <ItemtableContainer
+          TableContent={
+            loading ? (
+              <TableSkeleton />
+            ) : (
+              <ItemTableContent itemDatas={itemDatas} />
+            )
+          }
+        />
         {loading ? (
           <></>
         ) : (

--- a/app/(home)/page.tsx
+++ b/app/(home)/page.tsx
@@ -1,16 +1,16 @@
 "use client";
 
-import ItemTable from "@/components/ItemTable";
+import ItemTableContent from "@/components/ItemTableContent";
 import { QiitaItem, Query } from "@/type";
 import SearchBar from "@/components/SearchBar";
 import React, { useEffect, useState } from "react";
-import { Suspense } from "react";
 import { fetchItems } from "@/actions/items.action";
 import ApiKeyModal from "@/components/ApiKeyModal";
 import { useApiKeyContext } from "@/components/providers/ApiKeyProvider";
 import TableSkeleton from "@/components/TableSkeleton";
 import PrevButton from "@/components/PrevButton";
 import NextButton from "@/components/NextButton";
+import ItemtableContainer from "@/components/ItemTableContainer";
 
 export default function Home() {
   const initialQuery: Query = {
@@ -52,9 +52,7 @@ export default function Home() {
             <ApiKeyModal onRegister={handleRegister} />
           </div>
         </div>
-        <Suspense>
-          {loading ? <TableSkeleton /> : <ItemTable itemDatas={itemDatas} />}
-        </Suspense>
+        <ItemtableContainer TableContent={loading ? <TableSkeleton /> : <ItemTableContent itemDatas={itemDatas} />}/>
         {loading ? (
           <></>
         ) : (

--- a/app/(home)/page.tsx
+++ b/app/(home)/page.tsx
@@ -6,7 +6,7 @@ import SearchBar from "@/components/SearchBar";
 import React, { useEffect, useState } from "react";
 import { Suspense } from "react";
 import { fetchItems } from "@/actions/items.action";
-import Modal from "@/components/Modal";
+import ApiKeyModal from "@/components/ApiKeyModal";
 import { useApiKeyContext } from "@/components/providers/ApiKeyProvider";
 import TableSkeleton from "@/components/TableSkeleton";
 import PrevButton from "@/components/PrevButton";
@@ -49,7 +49,7 @@ export default function Home() {
         <div className="flex flex-raw">
           <SearchBar onSearch={handleSearch} />
           <div className="flex justify-items-end">
-            <Modal onRegister={handleRegister} />
+            <ApiKeyModal onRegister={handleRegister} />
           </div>
         </div>
         <Suspense>

--- a/components/ApiKeyModal.tsx
+++ b/components/ApiKeyModal.tsx
@@ -7,7 +7,7 @@ import { Input } from "./ui/input";
 import { Label } from "./ui/label";
 import { Button } from "./ui/button";
 
-const Modal = ( {onRegister} : {onRegister: (key: string) => void}) => {
+const ApiKeyModal = ( {onRegister} : {onRegister: (key: string) => void}) => {
     const [apiKey, setApiKey] = useState<string>("");
 
     const handleInputChange = (e:ChangeEvent<HTMLInputElement>) => {
@@ -50,4 +50,4 @@ const Modal = ( {onRegister} : {onRegister: (key: string) => void}) => {
     );
 };
 
-export default Modal;
+export default ApiKeyModal;

--- a/components/Item/ItemHeader.tsx
+++ b/components/Item/ItemHeader.tsx
@@ -3,7 +3,7 @@ import { CardContent, CardHeader, CardTitle } from "../ui/card";
 import { QiitaItem, QiitaUser } from "@/type";
 import { fetchUser } from "@/actions/items.action";
 import { useApiKeyContext } from "../providers/ApiKeyProvider";
-import UserInfo from "./UserInfo";
+import ItemUserInfo from "./ItemUserInfo";
 import { parseISO, format } from 'date-fns';
 import { IoMdHeartEmpty } from "react-icons/io";
 import { IoBookmarkOutline } from "react-icons/io5";
@@ -24,7 +24,7 @@ const ItemHeader = ({itemData}:{itemData:QiitaItem}) => {
     return (
         <CardHeader className="gap-1 border-b py-1">
             <CardContent className="p-0">
-                <UserInfo userData={userData}/>
+                {userLoading ? <></> : <ItemUserInfo userData={userData}/>}
             </CardContent>
             <CardTitle className="font-bold lg:text-3xl md:text-2xl sm:text-xl py-1">
                 {itemData.title}

--- a/components/Item/ItemHeader.tsx
+++ b/components/Item/ItemHeader.tsx
@@ -7,6 +7,7 @@ import ItemUserInfo from "./ItemUserInfo";
 import { parseISO, format } from 'date-fns';
 import { IoMdHeartEmpty } from "react-icons/io";
 import { IoBookmarkOutline } from "react-icons/io5";
+import UserInfoSkeleton from "./UserInfoSkeleton";
 
 
 const ItemHeader = ({itemData}:{itemData:QiitaItem}) => {
@@ -23,8 +24,8 @@ const ItemHeader = ({itemData}:{itemData:QiitaItem}) => {
 
     return (
         <CardHeader className="gap-1 border-b py-1">
-            <CardContent className="p-0">
-                {userLoading ? <></> : <ItemUserInfo userData={userData}/>}
+            <CardContent className="p-0 py-1">
+                {userLoading ? <UserInfoSkeleton/> : <ItemUserInfo userData={userData}/>}
             </CardContent>
             <CardTitle className="font-bold lg:text-3xl md:text-2xl sm:text-xl py-1">
                 {itemData.title}

--- a/components/Item/ItemUserInfo.tsx
+++ b/components/Item/ItemUserInfo.tsx
@@ -1,5 +1,4 @@
 import { QiitaUser } from "@/type";
-import Image from "next/image";
 import React from "react";
 
 const ItemUserInfo = ({userData}: {userData?: QiitaUser}) => {
@@ -7,7 +6,7 @@ const ItemUserInfo = ({userData}: {userData?: QiitaUser}) => {
         <div className="flex flex-col gap-1">
             {userData && (
                 <div className="flex flex-raw gap-2">
-                    <Image 
+                    <img
                     src={userData.profile_image_url} 
                     alt="profile image" 
                     width={32} 

--- a/components/Item/ItemUserInfo.tsx
+++ b/components/Item/ItemUserInfo.tsx
@@ -2,7 +2,7 @@ import { QiitaUser } from "@/type";
 import Image from "next/image";
 import React from "react";
 
-const UserInfo = ({userData}: {userData?: QiitaUser}) => {
+const ItemUserInfo = ({userData}: {userData?: QiitaUser}) => {
     return (
         <div className="flex flex-col gap-1">
             {userData && (
@@ -20,4 +20,4 @@ const UserInfo = ({userData}: {userData?: QiitaUser}) => {
     )
 }
 
-export default UserInfo;
+export default ItemUserInfo;

--- a/components/Item/UserInfoSkeleton.tsx
+++ b/components/Item/UserInfoSkeleton.tsx
@@ -1,0 +1,13 @@
+import React from "react";
+import { Skeleton } from "../ui/skeleton";
+
+const UserInfoSkeleton = () => {
+    return (
+        <div className="flex flex-raw gap-2 items-center">
+            <Skeleton className="rounded-full w-[32px] h-[32px]"/>
+            <Skeleton className="h-4 w-[80px]"/>
+        </div>
+    );
+};
+
+export default UserInfoSkeleton;

--- a/components/ItemTableContainer.tsx
+++ b/components/ItemTableContainer.tsx
@@ -1,0 +1,19 @@
+import { Table, TableHead, TableHeader, TableRow } from "./ui/table"
+import React from "react";
+
+const ItemtableContainer = ({TableContent} : {TableContent: React.ReactNode}) => {
+    return (
+        <Table>
+        <TableHeader>
+            <TableRow>
+                <TableHead>タイトル</TableHead>
+                <TableHead>ユーザID</TableHead>
+                <TableHead>URL</TableHead>
+            </TableRow>
+        </TableHeader>
+        {TableContent}
+      </Table>
+    )
+};
+
+export default ItemtableContainer;

--- a/components/ItemTableContent.tsx
+++ b/components/ItemTableContent.tsx
@@ -1,26 +1,15 @@
 import { QiitaItem } from "@/type";
 import React from "react";
 import {
-    Table,
     TableBody,
     TableCell,
-    TableHead,
-    TableHeader,
     TableRow,
 } from "@/components/ui/table";
 import Link from "next/link";
 import { Button } from "./ui/button";
 
-const ItemTable = async ({ itemDatas } : { itemDatas: QiitaItem[]}) =>  {
+const ItemTableContent = ({ itemDatas } : { itemDatas: QiitaItem[]}) =>  {
     return (
-      <Table>
-        <TableHeader>
-          <TableRow>
-            <TableHead>タイトル</TableHead>
-            <TableHead>ユーザID</TableHead>
-            <TableHead>URL</TableHead>
-          </TableRow>
-        </TableHeader>
         <TableBody>
           {itemDatas.map((itemData) => (
             <TableRow key={itemData.id}>
@@ -43,8 +32,7 @@ const ItemTable = async ({ itemDatas } : { itemDatas: QiitaItem[]}) =>  {
             </TableRow>
           ))}
         </TableBody>
-      </Table>
     )
   }
 
-export default ItemTable
+export default ItemTableContent

--- a/components/TableSkeleton.tsx
+++ b/components/TableSkeleton.tsx
@@ -8,10 +8,10 @@ const TableSkeleton = () => {
           {[...Array(5)].map((_, i) => (
             <TableRow key={i}>
               <TableCell>
-                <Skeleton className="h-4 w-[80px]" />
+                <Skeleton className="h-4 w-[270px]" />
               </TableCell>
               <TableCell>
-                <Skeleton className="h-4 w-[80px]" />
+                <Skeleton className="h-4 w-[120px]" />
               </TableCell>
               <TableCell>
                 <Skeleton className="h-4 w-[80px]" />

--- a/components/TableSkeleton.tsx
+++ b/components/TableSkeleton.tsx
@@ -1,17 +1,9 @@
-import { Table, TableHeader, TableRow, TableHead, TableBody, TableCell } from "@/components/ui/table"
+import {  TableRow, TableBody, TableCell } from "@/components/ui/table"
 import { Skeleton } from "@/components/ui/skeleton";
 import React from "react";
 
 const TableSkeleton = () => {
   return (
-      <Table>
-        <TableHeader>
-        <TableRow>
-            <TableHead>タイトル</TableHead>
-            <TableHead>ユーザID</TableHead>
-            <TableHead>URL</TableHead>
-          </TableRow>
-        </TableHeader>
         <TableBody>
           {[...Array(5)].map((_, i) => (
             <TableRow key={i}>
@@ -30,7 +22,6 @@ const TableSkeleton = () => {
             </TableRow>
           ))}
         </TableBody>
-      </Table>
   )
 }
 


### PR DESCRIPTION
## 概要
ItemTableコンポーネントおよびUserInfoコンポーネントの表示に関して変更をしました

## 実装内容
- ItemTable
  ItemTableContainerとItamTableContentコンポーネントに分割し, テーブルのヘッダーが再レンダリングされないようにしました
- UserInfo
  - ItemUserInfoへと改名
  - UserInfoSkeletonを実装