### PR TITLE
detail-pageの見た目を変更

### DIFF
--- a/app/(home)/[id]/_components/ItemHeader.tsx
+++ b/app/(home)/[id]/_components/ItemHeader.tsx
@@ -23,7 +23,7 @@ const ItemHeader = ({ itemData }: { itemData: QiitaItem }) => {
   }, []);
 
   return (
-    <CardHeader className="gap-1 border-b py-1">
+    <CardHeader className="gap-1 border-b py-1 mb-4">
       <CardContent className="p-0 py-1">
         {userLoading ? (
           <UserInfoSkeleton />

--- a/app/globals.css
+++ b/app/globals.css
@@ -2,13 +2,18 @@
 @tailwind components;
 @tailwind utilities;
 
+.py-05 {
+    padding-top: 0.125rem;
+    padding-bottom: 0.125rem;
+}
+
 .markdown {
     @apply text-gray-900 leading-normal break-words;
 }
 
-/* .markdown > * + * {
+.markdown > * + * {
     @apply mt-0 mb-4;
-} */
+}
 
 .markdown li + li {
     @apply mt-1;
@@ -59,7 +64,7 @@
 }
 
 .markdown code {
-    @apply font-mono text-sm inline bg-gray-200 rounded-sm;
+    @apply font-mono text-sm inline bg-gray-200 rounded-sm px-1;
 }
 
 .markdown pre {
@@ -79,7 +84,7 @@
 }
 
 .markdown kbd {
-    @apply text-xs inline-block rounded border px-1 py-5 align-middle font-normal font-mono shadow;
+    @apply text-xs inline-block rounded border px-1 py-05 align-middle font-normal font-mono shadow;
 }
 
 .markdown table {


### PR DESCRIPTION
closes #42 


## 概要
詳細ページの投稿を見やすいUIヘ変更しました

## 実装内容
ヘッダーとコンテンツ間のマージンを確保しました
コンテンツ内の要素間のマージンを確保しました