### PR TITLE
エラーハンドリング各ページで行うように修正しました

### DIFF
--- a/app/(home)/[id]/_components/ItemHeader.tsx
+++ b/app/(home)/[id]/_components/ItemHeader.tsx
@@ -14,18 +14,28 @@ const ItemHeader = ({ itemData }: { itemData: QiitaItem }) => {
   const apiKey = useRecoilValue(apiKeyState);
   const [userData, setUserData] = useState<QiitaUser | undefined>(undefined);
   const [userLoading, setUserLoading] = useState<boolean>(false);
+  const [error, setError] = useState<boolean>(false);
   useEffect(() => {
     setUserLoading(true);
-    fetchUser(itemData.user.id, apiKey).then((userData) => {
-      setUserLoading(false);
-      setUserData(userData);
-    });
+    fetchUser(itemData.user.id, apiKey)
+      .then((userData) => {
+        setUserLoading(false);
+        setUserData(userData);
+      })
+      .catch(() => {
+        setUserLoading(false);
+        setError(true);
+      });
   }, []);
 
   return (
     <CardHeader className="gap-1 border-b py-1 mb-4">
       <CardContent className="p-0 py-1">
-        {userLoading ? (
+        {error ? (
+          <div className="text-red-500 text-base flex my-2">
+            Error: Failed to get a user data.
+          </div>
+        ) : userLoading ? (
           <UserInfoSkeleton />
         ) : (
           <ItemUserInfo userData={userData} />

--- a/app/(home)/[id]/page.tsx
+++ b/app/(home)/[id]/page.tsx
@@ -12,18 +12,28 @@ const page = ({ params: { id } }: { params: { id: string } }) => {
   const apiKey = useRecoilValue(apiKeyState);
   const [itemData, setItemData] = useState<QiitaItem>();
   const [loading, setLoading] = useState<boolean>(false);
+  const [error, setError] = useState<boolean>(false);
   useLayoutEffect(() => {
     setLoading(true);
-    fetchItem(id, apiKey).then((itemData) => {
-      setItemData(itemData);
-      setLoading(false);
-    });
+    fetchItem(id, apiKey)
+      .then((itemData) => {
+        setItemData(itemData);
+        setLoading(false);
+      })
+      .catch(() => {
+        setLoading(false);
+        setError(true);
+      });
   }, []);
 
   return (
     <div className="flex flex-col gap-2">
       <BackButton />
-      {loading ? (
+      {error ? (
+        <div className="text-red-500 text-base flex my-2">
+          Error: Failed to get a data.
+        </div>
+      ) : loading ? (
         <ItemContainerSkeleton />
       ) : (
         <ItemContainer itemData={itemData} />

--- a/app/(home)/page.tsx
+++ b/app/(home)/page.tsx
@@ -46,7 +46,7 @@ export default function Home() {
         </div>
         {error ? (
           <div className="text-red-500 text-base flex my-2">
-            Error: cannnot get datas
+            Error: Failed to get datas.
           </div>
         ) : (
           !loading &&

--- a/app/(home)/user/[id]/_components/UserItems.tsx
+++ b/app/(home)/user/[id]/_components/UserItems.tsx
@@ -30,7 +30,7 @@ const UserItems = ({ userData }: { userData: QiitaUser }) => {
     <div className="flex flex-col gap-2">
       {error ? (
         <div className="text-red-500 text-base flex my-2">
-          Error: cannnot get datas
+          Error: Failed to get a datas.
         </div>
       ) : (
         !loading &&

--- a/app/(home)/user/[id]/page.tsx
+++ b/app/(home)/user/[id]/page.tsx
@@ -12,18 +12,32 @@ const page = ({ params: { id } }: { params: { id: string } }) => {
   const apiKey = useRecoilValue(apiKeyState);
   const [userData, setUserData] = useState<QiitaUser>();
   const [loading, setLoading] = useState<boolean>(false);
+  const [error, setError] = useState<boolean>(false);
   useLayoutEffect(() => {
     setLoading(true);
-    fetchUser(id, apiKey).then((userData) => {
-      setUserData(userData);
-      setLoading(false);
-    });
+    fetchUser(id, apiKey)
+      .then((userData) => {
+        setUserData(userData);
+        setLoading(false);
+      })
+      .catch(() => {
+        setLoading(false);
+        setError(true);
+      });
   }, []);
 
   return (
     <div className="flex flex-col gap-2">
       <BackButton />
-      {loading ? <></> : <UserContainer userData={userData}></UserContainer>}
+      {error ? (
+        <div className="text-red-500 text-base flex my-2">
+          Error: Failed to get a user data.
+        </div>
+      ) : loading ? (
+        <></>
+      ) : (
+        <UserContainer userData={userData}></UserContainer>
+      )}
     </div>
   );
 };


### PR DESCRIPTION
## 概要
データを取得する際に, 失敗したら, Failed to get...のような
メッセージを出力し, データ取得できなかったことを表示する

## 実装内容
各fetch関数が呼ばれた際に, errorが起きたらcatchするように修正しました
これにより, fetchに失敗した際, 常にloading状態になり, ユーザがデータ取得できているのかどうか
わからないという事態を回避できるようにしました